### PR TITLE
Explicitly set StartDate and EndDate to UTC using DateTime.SpecifyKind

### DIFF
--- a/TripPlanner/TripPlanner/Controllers/ItineraryController.cs
+++ b/TripPlanner/TripPlanner/Controllers/ItineraryController.cs
@@ -71,6 +71,10 @@ namespace TripPlanner.Controllers
             {
                 // Assign the current user as the owner before saving
                 itinerary.UserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+                itinerary.StartDate = DateTime.SpecifyKind(itinerary.StartDate, DateTimeKind.Utc);
+                itinerary.EndDate = DateTime.SpecifyKind(itinerary.EndDate, DateTimeKind.Utc);
+
                 _context.Add(itinerary);
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
@@ -131,6 +135,9 @@ namespace TripPlanner.Controllers
                     existing.Description = itinerary.Description;
                     existing.StartDate = itinerary.StartDate;
                     existing.EndDate = itinerary.EndDate;
+
+                    existing.StartDate = DateTime.SpecifyKind(itinerary.StartDate, DateTimeKind.Utc);
+                    existing.EndDate = DateTime.SpecifyKind(itinerary.EndDate, DateTimeKind.Utc);
 
                     _context.Update(existing);
                     await _context.SaveChangesAsync();


### PR DESCRIPTION
when creating or updating itineraries to prevent time zone ambiguity.